### PR TITLE
S-50: Typo when resolving bootstrap security vulnerability

### DIFF
--- a/closetr-web/package.json
+++ b/closetr-web/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "^7.0.4",
     "@angular/platform-browser-dynamic": "^7.0.4",
     "@angular/router": "^7.0.4",
-    "bootstrap": ">=4.1.3",
+    "bootstrap": ">=4.3.1",
     "bootstrap-toggle": "^2.2.2",
     "core-js": "^2.5.4",
     "jquery": "^3.3.1",


### PR DESCRIPTION
Ticket had to be reopened, as security vulnerability was not resolved,